### PR TITLE
IDataSeeder should be generic

### DIFF
--- a/src/Modules/Catalog/Catalog/CatalogModule.cs
+++ b/src/Modules/Catalog/Catalog/CatalogModule.cs
@@ -29,7 +29,7 @@ public static class CatalogModule
             options.UseNpgsql(connectionString);
         });
 
-        services.AddScoped<IDataSeeder, CatalogDataSeeder>();
+        services.AddScoped<IDataSeeder<CatalogDbContext>, CatalogDataSeeder>();
 
         return services;
     }

--- a/src/Modules/Catalog/Catalog/Data/Seed/CatalogDataSeeder.cs
+++ b/src/Modules/Catalog/Catalog/Data/Seed/CatalogDataSeeder.cs
@@ -1,8 +1,8 @@
 ﻿namespace Catalog.Data.Seed;
-public class CatalogDataSeeder(CatalogDbContext dbContext)
-    : IDataSeeder
+public class CatalogDataSeeder
+    : IDataSeeder<CatalogDbContext>
 {
-    public async Task SeedAllAsync()
+    public async Task SeedAllAsync(CatalogDbContext dbContext)
     {
         if (!await dbContext.Products.AnyAsync())
         {

--- a/src/Shared/Shared/Data/Extentions.cs
+++ b/src/Shared/Shared/Data/Extentions.cs
@@ -11,7 +11,7 @@ public static class Extentions
     {
         MigrateDatabaseAsync<TContext>(app.ApplicationServices).GetAwaiter().GetResult();
 
-        SeedDataAsync(app.ApplicationServices).GetAwaiter().GetResult();
+        SeedDataAsync<TContext>(app.ApplicationServices).GetAwaiter().GetResult();
 
         return app;
     }    
@@ -25,13 +25,15 @@ public static class Extentions
         await context.Database.MigrateAsync();
     }
 
-    private static async Task SeedDataAsync(IServiceProvider serviceProvider)
+    private static async Task SeedDataAsync<TContext>(IServiceProvider serviceProvider) where TContext : DbContext
     {
         using var scope = serviceProvider.CreateScope();
-        var seeders = scope.ServiceProvider.GetServices<IDataSeeder>();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+        
+        var seeders = scope.ServiceProvider.GetServices<IDataSeeder<TContext>>();
         foreach (var seeder in seeders)
         {
-            await seeder.SeedAllAsync();
+            await seeder.SeedAllAsync(context);
         }
     }
 }

--- a/src/Shared/Shared/Data/Seed/IDataSeeder.cs
+++ b/src/Shared/Shared/Data/Seed/IDataSeeder.cs
@@ -1,5 +1,5 @@
 ﻿namespace Shared.Data.Seed;
-public interface IDataSeeder
+public interface IDataSeeder<TContext> where TContext : DbContext
 {
-    Task SeedAllAsync();
+    Task SeedAllAsync(TContext context);
 }


### PR DESCRIPTION
With the way IDataSeeder is now, invoking UseMigration from one module will also seed data from other modules. Technically this causes no troubles, but it breaks module isolation.